### PR TITLE
Clause changes

### DIFF
--- a/Items/Accessory/AdamantiteRing.cs
+++ b/Items/Accessory/AdamantiteRing.cs
@@ -9,7 +9,7 @@ namespace SpiritMod.Items.Accessory
     {
         public override void SetStaticDefaults() {
             DisplayName.SetDefault("Adamantite Band");
-            Tooltip.SetDefault("Increases damage and critical strike chance by 10% when under half health, but decreases defense by 8");
+            Tooltip.SetDefault("Increases damage and critical strike chance by 10% when under half health\nDecreases defence by 8");
         }
 
 


### PR DESCRIPTION
Keeping the clauses separate can help prevent confusion- This way, it's more clear the ring *always* decreases defence by 8, and not just when their health is below half.