### PR TITLE
Atlas Eye Tooltip change

### DIFF
--- a/Items/Accessory/AtlasEye.cs
+++ b/Items/Accessory/AtlasEye.cs
@@ -8,7 +8,7 @@ namespace SpiritMod.Items.Accessory
     {
         public override void SetStaticDefaults() {
             DisplayName.SetDefault("Atlas Eye");
-            Tooltip.SetDefault("Under 50% health, movement speed is reduced by 1/3, but defense is increased by 20.\nReduces damage taken by 12%");
+            Tooltip.SetDefault("Under 50% health, defense is increased by 20, but movement speed is reduced by 1/3\nReduces damage taken by 12%");
         }
 
 


### PR DESCRIPTION
It is often better to list positives first, then negatives when involving trade-off effects. Unifying that system with the items that involve such trade-offs can help make user understanding easier.
Also removes periods at the end of line 1 of the tooltip for further unification.