### PR TITLE
Move life increase in Tooltip

### DIFF
--- a/Items/Accessory/BriarHeart.cs
+++ b/Items/Accessory/BriarHeart.cs
@@ -9,7 +9,7 @@ namespace SpiritMod.Items.Accessory
     {
         public override void SetStaticDefaults() {
             DisplayName.SetDefault("Briar Heart");
-            Tooltip.SetDefault("Increases melee damage by 5% and melee speed by 5%\nIncreases melee critical srike chance by 9% and ranged critical strike chance by 7%\nIncreases magic critical strike chance by 5% and maximum life by 20\nMagic attacks may inflict Cursed Inferno and Ichor\nGetting hurt may trigger 'Poison Bite,' causing all attacks to inflict poison for a short while\nIncreases maximum mana by 50");
+            Tooltip.SetDefault("Increases melee damage by 5% and melee speed by 5%\nIncreases melee critical srike chance by 9% and ranged critical strike chance by 7%\nIncreases magic critical strike chance by 5%\nMagic attacks may inflict Cursed Inferno and Ichor\nGetting hurt may trigger 'Poison Bite,' causing all attacks to inflict poison for a short while\nIncreases maximum mana by 50\nIncreases maximum life by 20");
 
         }
 


### PR DESCRIPTION
It makes little sense to pair the maximum life increase with the magic damage increase when there is already an increase to a similar resource elsewhere in the list. Separating it from the Magic Damage increase and instead including it after the Mana increase looks much neater.