### PR TITLE
Grammatical edit

### DIFF
--- a/Items/Accessory/Crystal.cs
+++ b/Items/Accessory/Crystal.cs
@@ -8,7 +8,7 @@ namespace SpiritMod.Items.Accessory
     {
         public override void SetStaticDefaults() {
             DisplayName.SetDefault("Crystal Distorter");
-            Tooltip.SetDefault("Ranged weapons have a chance to shoot out multiple projectiles\nThe duplicate projectiles usually lack special effects");
+            Tooltip.SetDefault("Ranged weapons have a chance to fire multiple projectiles\nThe duplicate projectiles usually lack special effects");
 
         }
 


### PR DESCRIPTION
While "shoot out" is completely valid, "fire" is much more succinct.