### PR TITLE
Death Rose Tooltip Tweaks

### DIFF
--- a/Items/Accessory/DeathRose.cs
+++ b/Items/Accessory/DeathRose.cs
@@ -7,7 +7,7 @@ namespace SpiritMod.Items.Accessory
     {
         public override void SetStaticDefaults() {
             DisplayName.SetDefault("Briar Blossom");
-            Tooltip.SetDefault("Press a hotkey to rapidly grow homing nature energy around the cursor position\nSuccessfully hitting enemies may cause the player to recieve 'Nature's Fury,' increasing damage and movement speed by 5%\n1 minute cooldown\nIncreases summoning damage by 6%");
+            Tooltip.SetDefault("Successfully hitting enemies may cause the player to recieve 'Nature's Fury', increasing damage and movement speed by 5%\nIncreases summoning damage by 6%\nPress a hotkey to rapidly grow homing nature energy around the cursor position\n1 minute cooldown");
         }
 
 


### PR DESCRIPTION
Moved the comma outside of "Nature's Fury", as it is part of the sentence, not part of the name.
Moved the hotkey ability and cooldown to the bottom of the tooltip to better communicate their relation.