### PR TITLE
Fiery Pendant Tooltip Fix

### DIFF
--- a/Items/Accessory/FieryPendant.cs
+++ b/Items/Accessory/FieryPendant.cs
@@ -8,7 +8,7 @@ namespace SpiritMod.Items.Accessory
     {
         public override void SetStaticDefaults() {
             DisplayName.SetDefault("Fiery Pendant");
-            Tooltip.SetDefault("Increases melee damage by 6% \nMelee weapons have a 30% chance to inflict on fire");
+            Tooltip.SetDefault("Increases melee damage by 6% \nMelee weapons have a 30% chance to inflict 'On Fire!'");
         }
 
 


### PR DESCRIPTION
fixes the 'on fire' to 'On Fire!', the actual debuff name.